### PR TITLE
Update of version in .vsixmanifest

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -15,7 +15,7 @@
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,16.0]" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="[16.0,18.0]" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
     </Installation>


### PR DESCRIPTION
Changed the version number for the extension 

The InstallationTarget element in the .vsixmanifest file is specifically targeting Visual Studio version 16.0 and not any versions higher than 16.0 on x86 architecture. Therefore, if you have a higher version of Visual Studio installed, such as Visual Studio Professional 2019 version 16.11.23, the extension may not be compatible.