### PR TITLE
Added stop sequence option and upgraded openai wrapper nuget

### DIFF
--- a/ChatGPT.cs
+++ b/ChatGPT.cs
@@ -1,4 +1,6 @@
-﻿using JeffPires.VisualChatGPTStudio.Options;
+﻿using EnvDTE;
+using JeffPires.VisualChatGPTStudio.Options;
+using Microsoft.Build.Framework.XamlTypes;
 using OpenAI_API;
 using OpenAI_API.Completions;
 using OpenAI_API.Models;
@@ -53,9 +55,21 @@ namespace JeffPires.VisualChatGPTStudio
                     break;
             }
 
-            CompletionRequest completionRequest = new CompletionRequest(request, model, options.MaxTokens, options.Temperature, presencePenalty: options.PresencePenalty, frequencyPenalty: options.FrequencyPenalty, top_p: options.TopP);
+
+            CompletionRequest completionRequest = new CompletionRequest(request, model, options.MaxTokens, options.Temperature, presencePenalty: options.PresencePenalty, 
+                frequencyPenalty: options.FrequencyPenalty, top_p: options.TopP, stopSequences: GetStopSequenceArray(options.StopSeqeuences));
 
             await api.Completions.StreamCompletionAsync(completionRequest, resultHandler);
         }
+
+        /// <summary>
+        ///  Returns an string array of stop sequences
+        /// </summary>
+        private static string[] GetStopSequenceArray(string option)
+        {
+            string[] stopSequenceArray = option.Split(',');
+            return stopSequenceArray;
+        }
+
     }
 }

--- a/Options/OptionPageGrid.cs
+++ b/Options/OptionPageGrid.cs
@@ -57,7 +57,7 @@ namespace JeffPires.VisualChatGPTStudio.Options
         public double TopP { get; set; } = 0;
 
         [Category("Visual chatGPT Studio")]
-        [DisplayName("stop sequence")]
+        [DisplayName("Stop sequence")]
         [Description("Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. Separate different stop strings by a comma e.g. '},;,stop'")]
         [DefaultValue("")]
         public string StopSeqeuences{ get; set; } = string.Empty;

--- a/Options/OptionPageGrid.cs
+++ b/Options/OptionPageGrid.cs
@@ -57,7 +57,7 @@ namespace JeffPires.VisualChatGPTStudio.Options
         public double TopP { get; set; } = 0;
 
         [Category("Visual chatGPT Studio")]
-        [DisplayName("Stop sequence")]
+        [DisplayName("Stop Sequences")]
         [Description("Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. Separate different stop strings by a comma e.g. '},;,stop'")]
         [DefaultValue("")]
         public string StopSeqeuences{ get; set; } = string.Empty;

--- a/Options/OptionPageGrid.cs
+++ b/Options/OptionPageGrid.cs
@@ -55,6 +55,12 @@ namespace JeffPires.VisualChatGPTStudio.Options
         [DefaultValue(0)]
         [TypeConverter(typeof(DoubleConverter))]
         public double TopP { get; set; } = 0;
+
+        [Category("Visual chatGPT Studio")]
+        [DisplayName("stop sequence")]
+        [Description("Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. Separate different stop strings by a comma e.g. '},;,stop'")]
+        [DefaultValue("")]
+        public string StopSeqeuences{ get; set; } = string.Empty;
     }
 
     /// <summary>


### PR DESCRIPTION
When running completions often would reach max length. Providing a stop character such as '}' seems an easy workaround to exit out of the code completion.