### PR TITLE
Add the ability to override the default model versions with a custom model. This is useful if using other API's outside of Open AI.

### DIFF
--- a/VisualChatGPTStudioShared/Options/OptionPageGrid.cs
+++ b/VisualChatGPTStudioShared/Options/OptionPageGrid.cs
@@ -161,6 +161,12 @@ namespace JeffPires.VisualChatGPTStudio.Options
         [TypeConverter(typeof(EnumConverter))]
         public ModelLanguageEnum Model { get; set; } = ModelLanguageEnum.GPT_3_5_Turbo;
 
+        [Category("OpenAI")]
+        [DisplayName("Model Language Override")]
+        [Description("Specify a custom model name for custom API's. Overrides Model Language is not null.")]
+        [DefaultValue("")]
+        public string CustomModel { get; set; } = "";
+
         #endregion OpenAI
 
         #region Turbo Chat

--- a/VisualChatGPTStudioShared/Utils/ChatGPT.cs
+++ b/VisualChatGPTStudioShared/Utils/ChatGPT.cs
@@ -120,7 +120,7 @@ namespace JeffPires.VisualChatGPTStudio.Utils
             chat.RequestParameters.FrequencyPenalty = options.FrequencyPenalty;
             chat.RequestParameters.PresencePenalty = options.PresencePenalty;
 
-            chat.Model = options.Model.GetStringValue();
+            chat.Model = string.IsNullOrEmpty(options.CustomModel) ? options.Model.GetStringValue() : options.CustomModel;
 
             return chat;
         }


### PR DESCRIPTION
I want to try out this extension with other API's, such as Claude, Groq and locally hosted models, which requires me to specify different models. Currently they are hardcoded to only Open AI's models. This change allows you to specify a custom model name for such usages.