### PR TITLE
Allow Visual Studio Authentication for Azure OpenAI Service

### DIFF
--- a/VisualChatGPTStudio.csproj
+++ b/VisualChatGPTStudio.csproj
@@ -111,6 +111,9 @@
     <PackageReference Include="AvalonEdit">
       <Version>6.3.0.90</Version>
     </PackageReference>
+    <PackageReference Include="Azure.Identity">
+      <Version>1.12.0</Version>
+    </PackageReference>
     <PackageReference Include="Community.VisualStudio.VSCT" Version="16.0.29.6" PrivateAssets="all" />
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.522" ExcludeAssets="Runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/VisualChatGPTStudio2019/VisualChatGPTStudio2019.csproj
+++ b/VisualChatGPTStudio2019/VisualChatGPTStudio2019.csproj
@@ -107,6 +107,9 @@
     <PackageReference Include="AvalonEdit">
       <Version>6.3.0.90</Version>
     </PackageReference>
+    <PackageReference Include="Azure.Identity">
+      <Version>1.12.0</Version>
+    </PackageReference>
     <PackageReference Include="Community.VisualStudio.Toolkit.16">
       <Version>16.0.522</Version>
     </PackageReference>

--- a/VisualChatGPTStudioShared/Commands/BaseCommand.cs
+++ b/VisualChatGPTStudioShared/Commands/BaseCommand.cs
@@ -69,6 +69,11 @@ namespace JeffPires.VisualChatGPTStudio.Commands
         /// </returns>
         protected bool ValidateAPIKey()
         {
+            if (OptionsGeneral.UseVisualStudioIdentity)
+            {
+                return true;
+            }
+
             if (string.IsNullOrWhiteSpace(OptionsGeneral.ApiKey))
             {
                 System.Windows.Forms.MessageBox.Show(Constants.MESSAGE_SET_API_KEY, Constants.EXTENSION_NAME);

--- a/VisualChatGPTStudioShared/Options/OptionPageGrid.cs
+++ b/VisualChatGPTStudioShared/Options/OptionPageGrid.cs
@@ -19,6 +19,12 @@ namespace JeffPires.VisualChatGPTStudio.Options
         public string ApiKey { get; set; }
 
         [Category("General")]
+        [DisplayName("Use VisualStudio Identity")]
+        [Description("Only available for Azure Open AI Service. If true, use your Microsoft Account to authenticate to the Azure Open AI Service.")]
+        [DefaultValue(false)]
+        public bool UseVisualStudioIdentity { get; set; }
+
+        [Category("General")]
         [DisplayName("OpenAI Service")]
         [Description("Select how to connect: OpenAI API or Azure OpenAI.")]
         [DefaultValue(OpenAIService.OpenAI)]

--- a/VisualChatGPTStudioShared/ToolWindows/TerminalWindow/TerminalWindowControl.xaml.cs
+++ b/VisualChatGPTStudioShared/ToolWindows/TerminalWindow/TerminalWindowControl.xaml.cs
@@ -52,7 +52,7 @@ namespace JeffPires.VisualChatGPTStudio.ToolWindows
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(options.ApiKey))
+                if (!options.UseVisualStudioIdentity && string.IsNullOrWhiteSpace(options.ApiKey))
                 {
                     MessageBox.Show(Constants.MESSAGE_SET_API_KEY, Constants.EXTENSION_NAME, MessageBoxButton.OK, MessageBoxImage.Warning);
 

--- a/VisualChatGPTStudioShared/ToolWindows/Turbo/ucChat.xaml.cs
+++ b/VisualChatGPTStudioShared/ToolWindows/Turbo/ucChat.xaml.cs
@@ -185,7 +185,7 @@ namespace JeffPires.VisualChatGPTStudio.ToolWindows.Turbo
             {
                 shiftKeyPressed = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift);
 
-                if (string.IsNullOrWhiteSpace(options.ApiKey))
+                if (!options.UseVisualStudioIdentity && string.IsNullOrWhiteSpace(options.ApiKey))
                 {
                     MessageBox.Show(Constants.MESSAGE_SET_API_KEY, Constants.EXTENSION_NAME, MessageBoxButton.OK, MessageBoxImage.Warning);
 

--- a/VisualChatGPTStudioShared/Utils/ChatGPT.cs
+++ b/VisualChatGPTStudioShared/Utils/ChatGPT.cs
@@ -264,7 +264,7 @@ namespace JeffPires.VisualChatGPTStudio.Utils
                     chatGPTHttpClient.SetProxy(options.Proxy);
                 }
 
-                azureAPI = OpenAIAPI.ForAzure(options.AzureResourceName, options.AzureDeploymentId, options.ApiKey);
+                azureAPI = OpenAIAPI.ForAzure(options.AzureResourceName, options.AzureDeploymentId, options.UseVisualStudioIdentity ? "unused" : options.ApiKey);
 
                 azureAPI.HttpClientFactory = chatGPTHttpClient;
             }
@@ -274,7 +274,7 @@ namespace JeffPires.VisualChatGPTStudio.Utils
                 CreateAzureApiHandler(options);
             }
 
-            if (azureAPI.Auth.ApiKey != options.ApiKey)
+            if (!options.UseVisualStudioIdentity && azureAPI.Auth.ApiKey != options.ApiKey)
             {
                 azureAPI.Auth.ApiKey = options.ApiKey;
             }

--- a/VisualChatGPTStudioShared/Utils/Http/ChatGPTHttpClientFactory.cs
+++ b/VisualChatGPTStudioShared/Utils/Http/ChatGPTHttpClientFactory.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Security;
 
 namespace JeffPires.VisualChatGPTStudio.Utils.Http
 {
@@ -97,23 +98,23 @@ namespace JeffPires.VisualChatGPTStudio.Utils.Http
         /// <returns>An HttpMessageHandler with the specified proxy settings.</returns>
         protected HttpMessageHandler CreateMessageHandler()
         {
-            HttpClientHandler handler;
-
-            if (options.LogRequests || options.LogResponses)
+            HttpClientHandler handler = new RequestCaptureHandler(options.LogRequests, options.LogResponses, options.UseVisualStudioIdentity)
             {
-                handler = new RequestCaptureHandler(options.LogRequests, options.LogResponses);
-            }
-            else
-            {
-                handler = new HttpClientHandler();
-            }
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                UseCookies = true,
+                AllowAutoRedirect = true,
+                ServerCertificateCustomValidationCallback = (sender, certificate, chain, sslPolicyErrors) => {
+                    if (sslPolicyErrors == SslPolicyErrors.None)
+                    {
+                        return true;
+                    }
 
-            handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-            handler.UseCookies = true;
-            handler.AllowAutoRedirect = true;
-            handler.ServerCertificateCustomValidationCallback = (a, b, c, d) => true;
-            handler.MaxConnectionsPerServer = 256;
-            handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls11 | System.Security.Authentication.SslProtocols.Tls;
+                    // Do not allow this client to communicate with unauthenticated servers.
+                    return false;
+                },
+                MaxConnectionsPerServer = 256,
+                SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls11 | System.Security.Authentication.SslProtocols.Tls
+            };
 
             if (!string.IsNullOrWhiteSpace(Proxy))
             {

--- a/VisualChatGPTStudioShared/Utils/Http/RequestCaptureHandler.cs
+++ b/VisualChatGPTStudioShared/Utils/Http/RequestCaptureHandler.cs
@@ -1,15 +1,36 @@
-﻿using System.Collections.Generic;using System.Net.Http;using System.Threading;using System.Threading.Tasks;namespace JeffPires.VisualChatGPTStudio.Utils.Http{
+﻿using Azure.Core;
+using Azure.Identity;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace JeffPires.VisualChatGPTStudio.Utils.Http
+{
     /// <summary>
     /// Represents a custom HTTP client handler that captures the request data.
     /// </summary>
-    public class RequestCaptureHandler : HttpClientHandler    {        private readonly bool logRequests;        private readonly bool logResponses;
+    public class RequestCaptureHandler : HttpClientHandler
+    {
+        private readonly bool logRequests;
+        private readonly bool logResponses;
+        private readonly bool useVisualStudioIdentity;
+        private static readonly TokenCredential tokenCredential = new CachedTokenCredential(new VisualStudioCredential());
+        private static readonly string[] scopes = ["https://cognitiveservices.azure.com/.default"];
 
         /// <summary>
         /// Initializes a new instance of the RequestCaptureHandler class.
         /// </summary>
         /// <param name="logRequests">A boolean value indicating whether requests should be logged.</param>
         /// <param name="logResponses">A boolean value indicating whether responses should be logged.</param>
-        public RequestCaptureHandler(bool logRequests, bool logResponses)        {            this.logRequests = logRequests;            this.logResponses = logResponses;        }
+        /// <param name="useVisualStudioIdentity">A boolean value indicating whether authentication should use Managed Identity.</param>
+        public RequestCaptureHandler(bool logRequests, bool logResponses, bool useVisualStudioIdentity)
+        {
+            this.logRequests = logRequests;
+            this.logResponses = logResponses;
+            this.useVisualStudioIdentity = useVisualStudioIdentity;
+        }
 
         /// <summary>
         /// Overrides the SendAsync method to log the request and response information.
@@ -17,6 +38,132 @@
         /// <param name="request">The HTTP request message.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The HTTP response message.</returns>
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)        {            string content;            if (logRequests)            {                Logger.Log($"Request URI: {request.RequestUri}");                Logger.Log($"Request Method: {request.Method}");                Logger.Log("Request Headers:");                foreach (KeyValuePair<string, IEnumerable<string>> header in request.Headers)                {                    Logger.Log($"{header.Key}: {string.Join(", ", header.Value)}");                }                if (request.Content != null)                {                    content = await request.Content.ReadAsStringAsync();                    Logger.Log("Request Content: " + content);                }                Logger.Log(new string('_', 100));            }            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);            if (response != null && logResponses)            {                Logger.Log("Response Headers:");                foreach (KeyValuePair<string, IEnumerable<string>> header in response.Headers)                {                    Logger.Log($"{header.Key}: {string.Join(", ", header.Value)}");                }                Logger.Log($"Response Status Code: {response.StatusCode}");                if (response.Content != null)                {                    content = await response.Content.ReadAsStringAsync();                    Logger.Log("Response Content: " + content);                }                Logger.Log(new string('_', 100));            }
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string content;
 
-            return response;        }    }}
+            if (logRequests)
+            {
+                Logger.Log($"Request URI: {request.RequestUri}");
+                Logger.Log($"Request Method: {request.Method}");
+                Logger.Log("Request Headers:");
+
+                foreach (KeyValuePair<string, IEnumerable<string>> header in request.Headers)
+                {
+                    Logger.Log($"{header.Key}: {string.Join(", ", header.Value)}");
+                }
+
+                if (request.Content != null)
+                {
+                    content = await request.Content.ReadAsStringAsync();
+
+                    Logger.Log("Request Content: " + content);
+                }
+
+                Logger.Log(new string('_', 100));
+            }
+
+            if (useVisualStudioIdentity)
+            {
+                var token = await tokenCredential.GetTokenAsync(new(scopes), cancellationToken);
+
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.Token);
+            }
+
+            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+
+            if (response != null && logResponses)
+            {
+                Logger.Log("Response Headers:");
+
+                foreach (KeyValuePair<string, IEnumerable<string>> header in response.Headers)
+                {
+                    Logger.Log($"{header.Key}: {string.Join(", ", header.Value)}");
+                }
+
+                Logger.Log($"Response Status Code: {response.StatusCode}");
+
+                if (response.Content != null)
+                {
+                    content = await response.Content.ReadAsStringAsync();
+
+                    Logger.Log("Response Content: " + content);
+                }
+
+                Logger.Log(new string('_', 100));
+            }
+
+            return response;
+        }
+
+        public class CachedTokenCredential(TokenCredential wrapped) : TokenCredential
+        {
+            private const int TokenExpirationOffset = 5;
+            private AccessToken? token = null;
+            private SemaphoreSlim tokenSemaphore = new(1);
+            private readonly TokenCredential wrapped = wrapped;
+
+            public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken = default)
+            {
+                if (!HasValidToken())
+                {
+                    await RenewTokenAsync(requestContext, cancellationToken);
+                }
+
+                return token.Value!;
+            }
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                if (!HasValidToken())
+                {
+                    RenewToken(requestContext, cancellationToken);
+                }
+
+                return token.Value!;
+            }
+
+            private async Task RenewTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                await tokenSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    if (HasValidToken())
+                    {
+                        return;
+                    }
+
+                    token = await wrapped.GetTokenAsync(requestContext, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    tokenSemaphore.Release();
+                }
+            }
+
+            private void RenewToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                tokenSemaphore.Wait(cancellationToken);
+                try
+                {
+                    if (HasValidToken())
+                    {
+                        return;
+                    }
+
+                    token = wrapped.GetToken(requestContext, cancellationToken);
+                }
+                finally
+                {
+                    tokenSemaphore.Release();
+                }
+            }
+
+            private bool HasValidToken()
+            {
+                return token != null
+                    && token.Value.ExpiresOn > DateTime.UtcNow.AddSeconds(TokenExpirationOffset);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an option to use Visual Studio authentication when using an Azure Open AI Service. 

The user doesn't have to know any APIKey in this scenario and can use its account to access the ressource.

![image](https://github.com/user-attachments/assets/8ffe0815-9c3f-4160-a4ce-2290ce843660)
