### PR TITLE
fix git-worktree repository detection logic

### DIFF
--- a/VisualChatGPTStudioShared/Utils/GitChanges.cs
+++ b/VisualChatGPTStudioShared/Utils/GitChanges.cs
@@ -121,7 +121,8 @@ namespace VisualChatGPTStudioShared.Utils
 
             while (directoryInfo?.Parent != null)
             {
-                if (System.IO.Directory.Exists(System.IO.Path.Combine(directoryInfo.FullName, ".git")))
+                string path = System.IO.Path.Combine(directoryInfo.FullName, ".git");
+                if (System.IO.Directory.Exists(path) || System.IO.File.Exists(path))
                 {
                     return directoryInfo.FullName;
                 }


### PR DESCRIPTION
[Git worktrees](https://git-scm.com/docs/git-worktree) do not contain a .git folder but instead have a .git file. The previous implementation only checked for the existence of a .git directory, which caused failures in recognizing repositories configured with Git worktrees.