### PR TITLE
Added ApiVersion override for Open AI Compatible API

### DIFF
--- a/VisualChatGPTStudioShared/Options/OptionPageGrid.cs
+++ b/VisualChatGPTStudioShared/Options/OptionPageGrid.cs
@@ -238,6 +238,12 @@ namespace JeffPires.VisualChatGPTStudio.Options
         [DefaultValue("gpt-4.1-mini")]
         public string Model { get; set; } = "gpt-4.1-mini";
 
+        [Category("OpenAI")]
+        [DisplayName("API Version Override")]
+        [Description("Change the API version to use custom endpoint")]
+        [DefaultValue("")]
+        public string ApiVersion { get; set; } = string.Empty;
+
         #endregion OpenAI
 
         #region Turbo Chat

--- a/VisualChatGPTStudioShared/Utils/ApiHandler.cs
+++ b/VisualChatGPTStudioShared/Utils/ApiHandler.cs
@@ -431,6 +431,12 @@ namespace JeffPires.VisualChatGPTStudio.Utils
                     openAiAPI.ApiUrlFormat = options.BaseAPI + "/{0}/{1}";
                 }
 
+                if (!string.IsNullOrWhiteSpace(options.ApiVersion))
+                {
+                    openAiAPI.ApiVersion = options.ApiVersion;
+                }
+
+
                 openAiAPI.HttpClientFactory = chatGPTHttpClient;
             }
             else if (IsOptionsParametersModified(options))


### PR DESCRIPTION
Hello! Thank you for your incredible extension! I want to use it with other OpenAI Compatible API with other Custom Endpoints and getting this error (as url is: "{CUSTOM_ENDPOINT}/v1/chat/completions") 

<img width="395" height="157" alt="screen_error" src="https://github.com/user-attachments/assets/7fa29e12-9a71-48f8-9985-c30a492f4ff8" />

This changes help me to override v1 with other endpoint:

<img width="1400" height="902" alt="screen_success_with_api_version_override" src="https://github.com/user-attachments/assets/7e498cc4-6659-412a-b36b-58bf1de71741" />
